### PR TITLE
Fix gccgo compile failure

### DIFF
--- a/transaction.c
+++ b/transaction.c
@@ -16,14 +16,16 @@ int cb_pam_conv(
 		return PAM_BUF_ERR;
 	}
 	for (size_t i = 0; i < num_msg; ++i) {
-		struct cbPAMConv_return result = cbPAMConv(
+		int ret = 0;
+		char *tmp = cbPAMConv(
 				msg[i]->msg_style,
 				(char *)msg[i]->msg,
-				(long)appdata_ptr);
-		if (result.r1 != PAM_SUCCESS) {
+				(long)appdata_ptr,
+				&ret);
+		if (ret != PAM_SUCCESS) {
 			goto error;
 		}
-		(*resp)[i].resp = result.r0;
+		(*resp)[i].resp = tmp;
 	}
 	return PAM_SUCCESS;
 error:

--- a/transaction.go
+++ b/transaction.go
@@ -53,7 +53,7 @@ func (f ConversationFunc) RespondPAM(s Style, msg string) (string, error) {
 
 // cbPAMConv is a wrapper for the conversation callback function.
 //export cbPAMConv
-func cbPAMConv(s C.int, msg *C.char, c int) (*C.char, C.int) {
+func cbPAMConv(s C.int, msg *C.char, c int, ret *C.int) *C.char {
 	var r string
 	var err error
 	v := cbGet(c)
@@ -62,9 +62,11 @@ func cbPAMConv(s C.int, msg *C.char, c int) (*C.char, C.int) {
 		r, err = cb.RespondPAM(Style(s), C.GoString(msg))
 	}
 	if err != nil {
-		return nil, C.PAM_CONV_ERR
+		*ret = C.PAM_CONV_ERR
+		return nil
 	}
-	return C.CString(r), C.PAM_SUCCESS
+	*ret = C.PAM_SUCCESS
+	return C.CString(r)
 }
 
 // Transaction is the application's handle for a PAM transaction.


### PR DESCRIPTION
Compiled with gccgo failed, errors:
```shell
# github.com/msteinert/pam                                                                                                                                                                    
/usr/share/gocode/src/github.com/msteinert/pam/transaction.c: In function ‘cb_pam_conv’:
/usr/share/gocode/src/github.com/msteinert/pam/transaction.c:19:10: error: variable ‘result’ has initializer but incomplete type                                                              
   struct cbPAMConv_return result = cbPAMConv(                                                                                                                                                
          ^~~~~~~~~~~~~~~~                                                                                                                                                                    
/usr/share/gocode/src/github.com/msteinert/pam/transaction.c:19:27: error: storage size of ‘result’ isn’t known                                                                               
   struct cbPAMConv_return result = cbPAMConv(                                                                                                                                                
                           ^~~~~~                                                                                                                                                             
/usr/share/gocode/src/github.com/msteinert/pam/transaction.c:19:27: warning: unused variable ‘result’ [-Wunused-variable]
```