### PR TITLE
Allow to define confdir 

### DIFF
--- a/my-service
+++ b/my-service
@@ -1,0 +1,2 @@
+# Custom stack to always permit, independent of the user name/pass
+auth	required			pam_permit.so

--- a/transaction.c
+++ b/transaction.c
@@ -50,3 +50,12 @@ void init_pam_conv(struct pam_conv *conv, long c)
 	conv->conv = cb_pam_conv;
 	conv->appdata_ptr = (void *)c;
 }
+
+// pam_start_confdir is a recent PAM api to declare a confdir (mostly for tests)
+// weaken the linking dependency to detect if it’s present.
+int pam_start_confdir(const char *service_name, const char *user, const struct pam_conv *pam_conversation, const char *confdir, pam_handle_t **pamh) __attribute__ ((weak));
+int check_pam_start_confdir(void) {
+	if (pam_start_confdir == NULL)
+		return 1;
+	return 0;
+}


### PR DESCRIPTION
PAM has a pam_start_confdir() which allows to define the configuration
directory where all services are located.
This is useful to define your own service on tests in particular, so
that you can control your stack and be independant of the host when
running them.
Allow defining this configuration directory, with functional options.
This keeps then the current package API while avoiding proliferation of
function namse, which would be doubled due to Start() and StartFunc()
flavors.

Add tests to cover this.