### PR TITLE
Safer transaction: add End() method and don't use as error

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+on: [push, pull_request]
+name: Lint
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: Install PAM
+        run: sudo apt install -y libpam-dev
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,61 @@
+# This is for linting. To run it, please use:
+# golangci-lint run ${MODULE}/... [--fix]
+
+linters:
+  # linters to run in addition to default ones
+  enable:
+    - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - gci
+    - godot
+    - gofmt
+    - gosec
+    - misspell
+    - nakedret
+    - nolintlint
+    - revive
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
+
+run:
+  timeout: 5m
+
+# Get all linter issues, even if duplicated
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  fix: false # we don’t want this in CI
+  exclude:
+    # EXC0001 errcheck: most errors are in defer calls, which are safe to ignore and idiomatic Go (would be good to only ignore defer ones though)
+    - 'Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv|w\.Stop). is not checked'
+    # EXC0008 gosec: duplicated of errcheck
+    - (G104|G307)
+    # EXC0010 gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
+    - Potential file inclusion via variable
+    # We want named parameters even if unused, as they help better document the function
+    - unused-parameter
+    # Sometimes it is more readable it do a `if err:=a(); err != nil` tha simpy `return a()`
+    - if-return
+
+nolintlint:
+  require-explanation: true
+  require-specific: true
+
+linters-settings:
+  # Forbid the usage of deprecated ioutil and debug prints
+  forbidigo:
+    forbid:
+      - ioutil\.
+      - ^print.*$
+  # Never have naked return ever
+  nakedret:
+    max-func-lines: 1

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,94 @@
+package pam
+
+/*
+#include <security/pam_appl.h>
+*/
+import "C"
+
+// Error is the Type for PAM Return types
+type Error int
+
+// Pam Return types
+const (
+	// OpenErr indicates a dlopen() failure when dynamically loading a
+	// service module.
+	ErrOpen Error = C.PAM_OPEN_ERR
+	// ErrSymbol indicates a symbol not found.
+	ErrSymbol Error = C.PAM_SYMBOL_ERR
+	// ErrService indicates a error in service module.
+	ErrService Error = C.PAM_SERVICE_ERR
+	// ErrSystem indicates a system error.
+	ErrSystem Error = C.PAM_SYSTEM_ERR
+	// ErrBuf indicates a memory buffer error.
+	ErrBuf Error = C.PAM_BUF_ERR
+	// ErrPermDenied indicates a permission denied.
+	ErrPermDenied Error = C.PAM_PERM_DENIED
+	// ErrAuth indicates a authentication failure.
+	ErrAuth Error = C.PAM_AUTH_ERR
+	// ErrCredInsufficient indicates a can not access authentication data due to
+	// insufficient credentials.
+	ErrCredInsufficient Error = C.PAM_CRED_INSUFFICIENT
+	// ErrAuthinfoUnavail indicates that the underlying authentication service
+	// can not retrieve authentication information.
+	ErrAuthinfoUnavail Error = C.PAM_AUTHINFO_UNAVAIL
+	// ErrUserUnknown indicates a user not known to the underlying authentication
+	// module.
+	ErrUserUnknown Error = C.PAM_USER_UNKNOWN
+	// ErrMaxtries indicates that an authentication service has maintained a retry
+	// count which has been reached. No further retries should be attempted.
+	ErrMaxtries Error = C.PAM_MAXTRIES
+	// ErrNewAuthtokReqd indicates a new authentication token required. This is
+	// normally returned if the machine security policies require that the
+	// password should be changed because the password is nil or it has aged.
+	ErrNewAuthtokReqd Error = C.PAM_NEW_AUTHTOK_REQD
+	// ErrAcctExpired indicates that an user account has expired.
+	ErrAcctExpired Error = C.PAM_ACCT_EXPIRED
+	// ErrSession indicates a can not make/remove an entry for the
+	// specified session.
+	ErrSession Error = C.PAM_SESSION_ERR
+	// ErrCredUnavail indicates that an underlying authentication service can not
+	// retrieve user credentials.
+	ErrCredUnavail Error = C.PAM_CRED_UNAVAIL
+	// ErrCredExpired indicates that an user credentials expired.
+	ErrCredExpired Error = C.PAM_CRED_EXPIRED
+	// ErrCred indicates a failure setting user credentials.
+	ErrCred Error = C.PAM_CRED_ERR
+	// ErrNoModuleData indicates a no module specific data is present.
+	ErrNoModuleData Error = C.PAM_NO_MODULE_DATA
+	// ErrConv indicates a conversation error.
+	ErrConv Error = C.PAM_CONV_ERR
+	// ErrAuthtokErr indicates an authentication token manipulation error.
+	ErrAuthtok Error = C.PAM_AUTHTOK_ERR
+	// ErrAuthtokRecoveryErr indicates an authentication information cannot
+	// be recovered.
+	ErrAuthtokRecovery Error = C.PAM_AUTHTOK_RECOVERY_ERR
+	// ErrAuthtokLockBusy indicates am authentication token lock busy.
+	ErrAuthtokLockBusy Error = C.PAM_AUTHTOK_LOCK_BUSY
+	// ErrAuthtokDisableAging indicates an authentication token aging disabled.
+	ErrAuthtokDisableAging Error = C.PAM_AUTHTOK_DISABLE_AGING
+	// ErrTryAgain indicates a preliminary check by password service.
+	ErrTryAgain Error = C.PAM_TRY_AGAIN
+	// ErrIgnore indicates to ignore underlying account module regardless of
+	// whether the control flag is required, optional, or sufficient.
+	ErrIgnore Error = C.PAM_IGNORE
+	// ErrAbort indicates a critical error (module fail now request).
+	ErrAbort Error = C.PAM_ABORT
+	// ErrAuthtokExpired indicates an user's authentication token has expired.
+	ErrAuthtokExpired Error = C.PAM_AUTHTOK_EXPIRED
+	// ErrModuleUnknown indicates a module is not known.
+	ErrModuleUnknown Error = C.PAM_MODULE_UNKNOWN
+	// ErrBadItem indicates a bad item passed to pam_*_item().
+	ErrBadItem Error = C.PAM_BAD_ITEM
+	// ErrConvAgain indicates a conversation function is event driven and data
+	// is not available yet.
+	ErrConvAgain Error = C.PAM_CONV_AGAIN
+	// ErrIncomplete indicates to please call this function again to complete
+	// authentication stack. Before calling again, verify that conversation
+	// is completed.
+	ErrIncomplete Error = C.PAM_INCOMPLETE
+)
+
+// Error returns the error message for the given status.
+func (status Error) Error() string {
+	return C.GoString(C.pam_strerror(nil, C.int(status)))
+}

--- a/transaction.go
+++ b/transaction.go
@@ -126,8 +126,6 @@ func cbPAMConv(s C.int, msg *C.char, c C.uintptr_t) (*C.char, C.int) {
 }
 
 // Transaction is the application's handle for a PAM transaction.
-//
-//nolint:errname
 type Transaction struct {
 	handle     *C.pam_handle_t
 	conv       *C.struct_pam_conv
@@ -215,10 +213,6 @@ func start(service, user string, handler ConversationHandler, confDir string) (*
 		return nil, err
 	}
 	return t, nil
-}
-
-func (t *Transaction) Error() string {
-	return Error(t.lastStatus.Load()).Error()
 }
 
 // Item is a an PAM information type.

--- a/transaction.go
+++ b/transaction.go
@@ -42,16 +42,16 @@ const (
 	PromptEchoOff Style = C.PAM_PROMPT_ECHO_OFF
 	// PromptEchoOn indicates the conversation handler should obtain a
 	// string while echoing text.
-	PromptEchoOn = C.PAM_PROMPT_ECHO_ON
+	PromptEchoOn Style = C.PAM_PROMPT_ECHO_ON
 	// ErrorMsg indicates the conversation handler should display an
 	// error message.
-	ErrorMsg = C.PAM_ERROR_MSG
+	ErrorMsg Style = C.PAM_ERROR_MSG
 	// TextInfo indicates the conversation handler should display some
 	// text.
-	TextInfo = C.PAM_TEXT_INFO
+	TextInfo Style = C.PAM_TEXT_INFO
 	// BinaryPrompt indicates the conversation handler that should implement
 	// the private binary protocol
-	BinaryPrompt = C.PAM_BINARY_PROMPT
+	BinaryPrompt Style = C.PAM_BINARY_PROMPT
 )
 
 // ConversationHandler is an interface for objects that can be used as
@@ -244,19 +244,19 @@ const (
 	// Service is the name which identifies the PAM stack.
 	Service Item = C.PAM_SERVICE
 	// User identifies the username identity used by a service.
-	User = C.PAM_USER
+	User Item = C.PAM_USER
 	// Tty is the terminal name.
-	Tty = C.PAM_TTY
+	Tty Item = C.PAM_TTY
 	// Rhost is the requesting host name.
-	Rhost = C.PAM_RHOST
+	Rhost Item = C.PAM_RHOST
 	// Authtok is the currently active authentication token.
-	Authtok = C.PAM_AUTHTOK
+	Authtok Item = C.PAM_AUTHTOK
 	// Oldauthtok is the old authentication token.
-	Oldauthtok = C.PAM_OLDAUTHTOK
+	Oldauthtok Item = C.PAM_OLDAUTHTOK
 	// Ruser is the requesting user name.
-	Ruser = C.PAM_RUSER
+	Ruser Item = C.PAM_RUSER
 	// UserPrompt is the string use to prompt for a username.
-	UserPrompt = C.PAM_USER_PROMPT
+	UserPrompt Item = C.PAM_USER_PROMPT
 )
 
 // SetItem sets a PAM information item.
@@ -287,21 +287,21 @@ const (
 	Silent Flags = C.PAM_SILENT
 	// DisallowNullAuthtok indicates that authorization should fail
 	// if the user does not have a registered authentication token.
-	DisallowNullAuthtok = C.PAM_DISALLOW_NULL_AUTHTOK
+	DisallowNullAuthtok Flags = C.PAM_DISALLOW_NULL_AUTHTOK
 	// EstablishCred indicates that credentials should be established
 	// for the user.
-	EstablishCred = C.PAM_ESTABLISH_CRED
+	EstablishCred Flags = C.PAM_ESTABLISH_CRED
 	// DeleteCred inidicates that credentials should be deleted.
-	DeleteCred = C.PAM_DELETE_CRED
+	DeleteCred Flags = C.PAM_DELETE_CRED
 	// ReinitializeCred indicates that credentials should be fully
 	// reinitialized.
-	ReinitializeCred = C.PAM_REINITIALIZE_CRED
+	ReinitializeCred Flags = C.PAM_REINITIALIZE_CRED
 	// RefreshCred indicates that the lifetime of existing credentials
 	// should be extended.
-	RefreshCred = C.PAM_REFRESH_CRED
+	RefreshCred Flags = C.PAM_REFRESH_CRED
 	// ChangeExpiredAuthtok indicates that the authentication token
 	// should be changed if it has expired.
-	ChangeExpiredAuthtok = C.PAM_CHANGE_EXPIRED_AUTHTOK
+	ChangeExpiredAuthtok Flags = C.PAM_CHANGE_EXPIRED_AUTHTOK
 )
 
 // Authenticate is used to authenticate the user.

--- a/transaction.go
+++ b/transaction.go
@@ -257,6 +257,14 @@ const (
 	Ruser Item = C.PAM_RUSER
 	// UserPrompt is the string use to prompt for a username.
 	UserPrompt Item = C.PAM_USER_PROMPT
+	// FailDelay is the app supplied function to override failure delays.
+	FailDelay Item = C.PAM_FAIL_DELAY
+	// Xdisplay is the X display name
+	Xdisplay Item = C.PAM_XDISPLAY
+	// Xauthdata is the X server authentication data.
+	Xauthdata Item = C.PAM_XAUTHDATA
+	// AuthtokType is the type for pam_get_authtok
+	AuthtokType Item = C.PAM_AUTHTOK_TYPE
 )
 
 // SetItem sets a PAM information item.

--- a/transaction.go
+++ b/transaction.go
@@ -173,7 +173,7 @@ func Start(service, user string, handler ConversationHandler) (*Transaction, err
 // StartFunc registers the handler func as a conversation handler and starts
 // the transaction (see Start() documentation).
 func StartFunc(service, user string, handler func(Style, string) (string, error)) (*Transaction, error) {
-	return Start(service, user, ConversationFunc(handler))
+	return start(service, user, ConversationFunc(handler), "")
 }
 
 // StartConfDir initiates a new PAM transaction. Service is treated identically to
@@ -212,6 +212,7 @@ func start(service, user string, handler ConversationHandler, confDir string) (*
 		conv: &C.struct_pam_conv{},
 		c:    cgo.NewHandle(handler),
 	}
+
 	C.init_pam_conv(t.conv, C.uintptr_t(t.c))
 	s := C.CString(service)
 	defer C.free(unsafe.Pointer(s))

--- a/transaction.go
+++ b/transaction.go
@@ -299,7 +299,7 @@ const (
 	// EstablishCred indicates that credentials should be established
 	// for the user.
 	EstablishCred Flags = C.PAM_ESTABLISH_CRED
-	// DeleteCred inidicates that credentials should be deleted.
+	// DeleteCred indicates that credentials should be deleted.
 	DeleteCred Flags = C.PAM_DELETE_CRED
 	// ReinitializeCred indicates that credentials should be fully
 	// reinitialized.

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -167,8 +167,8 @@ func TestPAM_007(t *testing.T) {
 	if len(s) == 0 {
 		t.Fatalf("error #expected an error message")
 	}
-	if tx.Error() != ErrAuth.Error() {
-		t.Fatalf("error #unexpected status %v", tx.Error())
+	if !errors.Is(err, ErrAuth) {
+		t.Fatalf("error #unexpected error %v", err)
 	}
 }
 
@@ -255,8 +255,8 @@ func TestPAM_ConfDir_Deny(t *testing.T) {
 	if len(s) == 0 {
 		t.Fatalf("error #expected an error message")
 	}
-	if tx.Error() != ErrAuth.Error() {
-		t.Fatalf("error #unexpected status %v", tx.Error())
+	if !errors.Is(err, ErrAuth) {
+		t.Fatalf("error #unexpected error %v", err)
 	}
 }
 
@@ -304,8 +304,8 @@ func TestPAM_ConfDir_WrongUserName(t *testing.T) {
 	if len(s) == 0 {
 		t.Fatalf("error #expected an error message")
 	}
-	if tx.Error() != ErrAuth.Error() {
-		t.Fatalf("error #unexpected status %v", tx.Error())
+	if !errors.Is(err, ErrAuth) {
+		t.Fatalf("error #unexpected error %v", err)
 	}
 }
 
@@ -416,7 +416,7 @@ func Test_Error(t *testing.T) {
 	}
 
 	statuses := map[string]error{
-		"success":               Error(success),
+		"success":               nil,
 		"open_err":              ErrOpen,
 		"symbol_err":            ErrSymbol,
 		"service_err":           ErrService,
@@ -441,7 +441,7 @@ func Test_Error(t *testing.T) {
 		"authtok_lock_busy":     ErrAuthtokLockBusy,
 		"authtok_disable_aging": ErrAuthtokDisableAging,
 		"try_again":             ErrTryAgain,
-		"ignore":                Error(success), /* Ignore can't be returned */
+		"ignore":                nil, /* Ignore can't be returned */
 		"abort":                 ErrAbort,
 		"authtok_expired":       ErrAuthtokExpired,
 		"module_unknown":        ErrModuleUnknown,
@@ -504,13 +504,17 @@ func Test_Error(t *testing.T) {
 					err = tx.OpenSession(0)
 				}
 
-				if tx.Error() != expected.Error() {
-					t.Fatalf("error #unexpected status %v", tx.Error())
+				if !errors.Is(err, expected) {
+					t.Fatalf("error #unexpected status %#v vs %#v", err,
+						expected)
 				}
-				if tx.Error() == Error(success).Error() && err != nil {
-					t.Fatalf("error #unexpected: %v", err)
-				} else if tx.Error() != Error(success).Error() && err == nil {
-					t.Fatalf("error #expected an error message")
+
+				if err != nil {
+					var status Error
+					if !errors.As(err, &status) || err.Error() != status.Error() {
+						t.Fatalf("error #unexpected status %v vs %v", err.Error(),
+							status.Error())
+					}
 				}
 			})
 		}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -2,7 +2,10 @@ package pam
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"os/user"
+	"path/filepath"
 	"testing"
 )
 
@@ -164,6 +167,9 @@ func TestPAM_007(t *testing.T) {
 	if len(s) == 0 {
 		t.Fatalf("error #expected an error message")
 	}
+	if tx.Error() != ErrAuth.Error() {
+		t.Fatalf("error #unexpected status %v", tx.Error())
+	}
 }
 
 func TestPAM_ConfDir(t *testing.T) {
@@ -242,6 +248,9 @@ func TestPAM_ConfDir_Deny(t *testing.T) {
 	if len(s) == 0 {
 		t.Fatalf("error #expected an error message")
 	}
+	if tx.Error() != ErrAuth.Error() {
+		t.Fatalf("error #unexpected status %v", tx.Error())
+	}
 }
 
 func TestPAM_ConfDir_PromptForUserName(t *testing.T) {
@@ -287,6 +296,9 @@ func TestPAM_ConfDir_WrongUserName(t *testing.T) {
 	s := err.Error()
 	if len(s) == 0 {
 		t.Fatalf("error #expected an error message")
+	}
+	if tx.Error() != ErrAuth.Error() {
+		t.Fatalf("error #unexpected status %v", tx.Error())
 	}
 }
 
@@ -387,6 +399,114 @@ func TestEnv(t *testing.T) {
 	}
 	if m["VAL3"] != "3" {
 		t.Fatalf("getenvlist #error: expected 3, got %v", m["VAL1"])
+	}
+}
+
+func Test_Error(t *testing.T) {
+	t.Parallel()
+	if !CheckPamHasStartConfdir() {
+		t.Skip("this requires PAM with Conf dir support")
+	}
+
+	statuses := map[string]error{
+		"success":               Error(success),
+		"open_err":              ErrOpen,
+		"symbol_err":            ErrSymbol,
+		"service_err":           ErrService,
+		"system_err":            ErrSystem,
+		"buf_err":               ErrBuf,
+		"perm_denied":           ErrPermDenied,
+		"auth_err":              ErrAuth,
+		"cred_insufficient":     ErrCredInsufficient,
+		"authinfo_unavail":      ErrAuthinfoUnavail,
+		"user_unknown":          ErrUserUnknown,
+		"maxtries":              ErrMaxtries,
+		"new_authtok_reqd":      ErrNewAuthtokReqd,
+		"acct_expired":          ErrAcctExpired,
+		"session_err":           ErrSession,
+		"cred_unavail":          ErrCredUnavail,
+		"cred_expired":          ErrCredExpired,
+		"cred_err":              ErrCred,
+		"no_module_data":        ErrNoModuleData,
+		"conv_err":              ErrConv,
+		"authtok_err":           ErrAuthtok,
+		"authtok_recover_err":   ErrAuthtokRecovery,
+		"authtok_lock_busy":     ErrAuthtokLockBusy,
+		"authtok_disable_aging": ErrAuthtokDisableAging,
+		"try_again":             ErrTryAgain,
+		"ignore":                Error(success), /* Ignore can't be returned */
+		"abort":                 ErrAbort,
+		"authtok_expired":       ErrAuthtokExpired,
+		"module_unknown":        ErrModuleUnknown,
+		"bad_item":              ErrBadItem,
+		"conv_again":            ErrConvAgain,
+		"incomplete":            ErrIncomplete,
+	}
+
+	type Action int
+	const (
+		account Action = iota + 1
+		auth
+		password
+		session
+	)
+	actions := map[string]Action{
+		"account":  account,
+		"auth":     auth,
+		"password": password,
+		"session":  session,
+	}
+
+	c := Credentials{}
+
+	servicePath := t.TempDir()
+
+	for ret, expected := range statuses {
+		ret := ret
+		expected := expected
+		for actionName, action := range actions {
+			actionName := actionName
+			action := action
+			t.Run(fmt.Sprintf("%s %s", ret, actionName), func(t *testing.T) {
+				t.Parallel()
+				serviceName := ret + "-" + actionName
+				serviceFile := filepath.Join(servicePath, serviceName)
+				contents := fmt.Sprintf("%[1]s requisite pam_debug.so "+
+					"auth=%[2]s cred=%[2]s acct=%[2]s prechauthtok=%[2]s "+
+					"chauthtok=%[2]s open_session=%[2]s close_session=%[2]s\n"+
+					"%[1]s requisite pam_permit.so\n", actionName, ret)
+
+				if err := os.WriteFile(serviceFile,
+					[]byte(contents), 0600); err != nil {
+					t.Fatalf("can't create service file %v: %v", serviceFile, err)
+				}
+
+				tx, err := StartConfDir(serviceName, "user", c, servicePath)
+				if err != nil {
+					t.Fatalf("start #error: %v", err)
+				}
+
+				switch action {
+				case account:
+					err = tx.AcctMgmt(0)
+				case auth:
+					err = tx.Authenticate(0)
+				case password:
+					err = tx.ChangeAuthTok(0)
+				case session:
+					err = tx.OpenSession(0)
+				}
+
+				if tx.Error() != expected.Error() {
+					t.Fatalf("error #unexpected status %v", tx.Error())
+				}
+				if tx.Error() == Error(success).Error() && err != nil {
+					t.Fatalf("error #unexpected: %v", err)
+				} else if tx.Error() != Error(success).Error() && err == nil {
+					t.Fatalf("error #expected an error message")
+				}
+			})
+		}
 	}
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -512,7 +512,7 @@ func Test_Error(t *testing.T) {
 				if err != nil {
 					var status Error
 					if !errors.As(err, &status) || err.Error() != status.Error() {
-						t.Fatalf("error #unexpected status %v vs %v", err.Error(),
+						t.Fatalf("error #unexpected status %#v vs %#v", err.Error(),
 							status.Error())
 					}
 				}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -208,6 +208,13 @@ func TestPAM_ConfDir_FailNoServiceOrUnsupported(t *testing.T) {
 	if len(s) == 0 {
 		t.Fatalf("error #expected an error message")
 	}
+	var pamErr Error
+	if !errors.As(err, &pamErr) {
+		t.Fatalf("error #unexpected type: %#v", err)
+	}
+	if pamErr != ErrAbort {
+		t.Fatalf("error #unexpected status: %v", pamErr)
+	}
 }
 
 func TestPAM_ConfDir_InfoMessage(t *testing.T) {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -160,6 +160,13 @@ func TestPAM_005(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start #error: %v", err)
 	}
+	service, err := tx.GetItem(Service)
+	if err != nil {
+		t.Fatalf("GetItem #error: %v", err)
+	}
+	if service != "passwd" {
+		t.Fatalf("Unexpected service: %v", service)
+	}
 	err = tx.ChangeAuthTok(Silent)
 	if err != nil {
 		t.Fatalf("chauthtok #error: %v", err)
@@ -234,6 +241,13 @@ func TestPAM_ConfDir(t *testing.T) {
 		// nothing else we do, we don't support it.
 		return
 	}
+	service, err := tx.GetItem(Service)
+	if err != nil {
+		t.Fatalf("GetItem #error: %v", err)
+	}
+	if service != "permit-service" {
+		t.Fatalf("Unexpected service: %v", service)
+	}
 	if err != nil {
 		t.Fatalf("start #error: %v", err)
 	}
@@ -285,6 +299,13 @@ func TestPAM_ConfDir_InfoMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start #error: %v", err)
 	}
+	service, err := tx.GetItem(Service)
+	if err != nil {
+		t.Fatalf("GetItem #error: %v", err)
+	}
+	if service != "echo-service" {
+		t.Fatalf("Unexpected service: %v", service)
+	}
 	err = tx.Authenticate(0)
 	if err != nil {
 		t.Fatalf("authenticate #error: %v", err)
@@ -301,6 +322,13 @@ func TestPAM_ConfDir_Deny(t *testing.T) {
 	defer maybeEndTransaction(t, tx)
 	if err != nil {
 		t.Fatalf("start #error: %v", err)
+	}
+	service, err := tx.GetItem(Service)
+	if err != nil {
+		t.Fatalf("GetItem #error: %v", err)
+	}
+	if service != "deny-service" {
+		t.Fatalf("Unexpected service: %v", service)
 	}
 	err = tx.Authenticate(0)
 	if err == nil {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -258,6 +258,9 @@ func TestPAM_ConfDir(t *testing.T) {
 }
 
 func TestPAM_ConfDir_FailNoServiceOrUnsupported(t *testing.T) {
+	if !CheckPamHasStartConfdir() {
+		t.Skip("this requires PAM with Conf dir support")
+	}
 	u, _ := user.Current()
 	c := Credentials{
 		Password: "secret",
@@ -316,6 +319,9 @@ func TestPAM_ConfDir_InfoMessage(t *testing.T) {
 }
 
 func TestPAM_ConfDir_Deny(t *testing.T) {
+	if !CheckPamHasStartConfdir() {
+		t.Skip("this requires PAM with Conf dir support")
+	}
 	u, _ := user.Current()
 	tx, err := StartConfDir("deny-service", u.Username, Credentials{}, "test-services")
 	ensureTransactionEnds(t, tx)


### PR DESCRIPTION
As per discussions we had, Transaction is not fully thread safe and the fact it could be returned as an error makes things worse because its Error() value, that depends on the state could be changed while it's processed.

So:
 - Always return error structure/status values instead of the transaction itself
 - Remove the finalizer (or maybe make it toggable) adding an `End()` method.

These are both breaking changes, but would simplify #13 too.

Closes: #14 

---

Note that this also includes #16 