### PR TITLE
transaction: Ignore unused variable warnings

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -1,7 +1,7 @@
 // Package pam provides a wrapper for the PAM application API.
 package pam
 
-//#cgo CFLAGS: -Wall -std=c99
+//#cgo CFLAGS: -Wall -Wno-unused-variable -std=c99
 //#cgo LDFLAGS: -lpam
 //
 //#include <security/pam_appl.h>


### PR DESCRIPTION
We may get some warnings when generating code as:
  warning: unused variable ‘_cgo_a’

This is something due to the fact we use `-Wall` that is not something golang upstream suggests.

However, since this is the only warning we may have and it's not a super relevant one, we can ensure we ignore it.