### PR TITLE
CI: Fix container preparation issues

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,9 @@ jobs:
           go-version: '1.21'
           cache: false
       - name: Install PAM
-        run: sudo apt install -y libpam-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpam-dev
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,19 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Install PAM
-      run: sudo apt install -y libpam-dev
+    - name: Update system
+      run: |
+        sudo apt-get update -y
+        sudo apt-get dist-upgrade -y
+    - name: Install PAM with debug symbols
+      run: |
+        sudo apt-get install ubuntu-dbgsym-keyring -y
+        echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse
+        deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
+        deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
+        sudo tee -a /etc/apt/sources.list.d/ddebs.list
+        sudo apt-get update -y
+        sudo apt-get install -y libpam-dev libpam-modules-dbgsym libpam0*-dbgsym
     - name: Add a test user
       run: sudo useradd -d /tmp/test -p '$1$Qd8H95T5$RYSZQeoFbEB.gS19zS99A0' -s /bin/false test
     - name: Checkout code


### PR DESCRIPTION
CI is currently failing now because we didn't update the repos correctly, and pam library has been updated recently.