### PR TITLE
struct pam_message on illumos is now const

### DIFF
--- a/transaction.c
+++ b/transaction.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#ifdef __sun
+#if defined(__sun) && !defined(__illumos__)
 #define PAM_CONST
 #else
 #define PAM_CONST const


### PR DESCRIPTION
Recently, illumos made updates to more closely resemble behaviour on Linux. As a consequence the API changed, which could be seen here: https://github.com/illumos/illumos-gate/commit/cbea7aca3fd7787405cbdbd93752998f03dfc25f#diff-b67d48b0442abc56dfcd872e8a508cba0c0173a665beba271f31188b45b70d57R143. There is still compatibility with prior behaviour via the `_PAM_LEGACY_NONCONST` define, but this should normally be undefined. Thus, `struct pam_message **` is now `const struct pam_message **`.

As a consequence on latest stable OmniOS system (omnios-r151052-dbe4644ba92) we can see the following warning.
```
# github.com/msteinert/pam
transaction.c: In function 'init_pam_conv':
transaction.c:50:13: warning: assignment to 'int (*)(int,  const struct pam_message **, struct pam_response **, void *)' from incompatible pointer type 'int (*)(int,  struct pam_message **, struct pam_response **, void *)' [-Wincompatible-pointer-types]
   50 |  conv->conv = cb_pam_conv;
      |
```
With this PR we exclude Illumos, leaving the behaviour unchanged as long as the `__illumos__` define is not present.