### PR TITLE
Add #define _GNU_SOURCE so that transaction.go can reference C.RTLD_NEXT

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -5,6 +5,7 @@ package pam
 #cgo CFLAGS: -Wall -Wno-unused-variable -std=c99
 #cgo LDFLAGS: -ldl -lpam
 
+#define _GNU_SOURCE
 #include <dlfcn.h>
 #include <security/pam_appl.h>
 #include <stdlib.h>
@@ -16,6 +17,10 @@ package pam
 #include <limits.h>
 #define PAM_BINARY_PROMPT INT_MAX
 #define BINARY_PROMPT_IS_SUPPORTED 0
+#endif
+
+#ifndef RTLD_NEXT
+# define RTLD_NEXT      ((void *) -1l)
 #endif
 
 void init_pam_conv(struct pam_conv *conv, uintptr_t);


### PR DESCRIPTION
RTLD_NEXT is inside a #ifdef __USE_GNU block in dlfcn.h, which causes the build to fail 

This in AlmaLinux release 8.10 (Cerulean Leopard), binary compatible with RHEL

fixes #34